### PR TITLE
Bugfix/10.02

### DIFF
--- a/js/component_attrs.js
+++ b/js/component_attrs.js
@@ -142,7 +142,7 @@ ComponentAttrs_Batchlist.prototype.CreateColumnList_Options = function()
 	var columnlist =
 	[
 		new MMBatchList_Column_Code( 'Attribute ID', 'attr_id', 'attr_id' )
-				.SetRootColumn( self.attr_id )
+				.SetRootColumn( self.id )
 				.SetSearchable( false )
 				.SetDisplayInList( false ),
 		new MMBatchList_Column_Code( 'Option ID', 'id', 'id' )

--- a/tgcomponents.mv
+++ b/tgcomponents.mv
@@ -2,7 +2,7 @@
 	<MvASSIGN NAME = "l.module:code"		VALUE = "TGCOMPONENTS">
 	<MvASSIGN NAME = "l.module:name"		VALUE = "Components & Layouts">
 	<MvASSIGN NAME = "l.module:provider"	VALUE = "Tess Guefen">
-	<MvASSIGN NAME = "l.module:version"		VALUE = "1.019">
+	<MvASSIGN NAME = "l.module:version"		VALUE = "1.020">
 	<MvASSIGN NAME = "l.module:api_ver"		VALUE = "9.12">
 	<MvASSIGN NAME = "l.module:description"	VALUE = "Create components to easily manipulate customized layouts.">
 	<MvASSIGN NAME = "l.module:features"	VALUE = "data_store, util, component, json, clientside, provision_store, export, scheduledtask">

--- a/tgcomponents.mv
+++ b/tgcomponents.mv
@@ -61,6 +61,8 @@
 		- BUGFIX: MM10
 	1.019
 		- BUGFIX: Removed `opt.code` (random). And changed "View Layout" button placement to be first.
+	1.020
+		- BUGFIX: `attr_id` didn't exist in batchlist, utilized `id`
 </MvCOMMENT>
 
 <MvCOMMENT>


### PR DESCRIPTION
BUGFIX: `attr_id` didn't exist in batchlist, utilized `id`